### PR TITLE
Switch to pkg-config to detect libsqlite3 CFLAGS/LDFLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ $ cp ~/Downloads/sqlite-amalgamation-xxx/sqlite3.{c,h} $GOPATH/src/github.com/gw
 - patch sqlite.go file
 
 ```
--#cgo LDFLAGS: -lsqlite3
+-#cgo linux freebsd pkg-config: sqlite3
+-#cgo !linux,!freebsd LDFLAGS: -lsqlite3
 +#cgo CFLAGS: -I.
 +#cgo CFLAGS: -DSQLITE_ENABLE_COLUMN_METADATA=1
 ```

--- a/sqlite.go
+++ b/sqlite.go
@@ -6,9 +6,8 @@
 package sqlite
 
 /*
-#cgo LDFLAGS: -lsqlite3
-#cgo freebsd LDFLAGS: -lsqlite3 -L/usr/local/lib
-#cgo freebsd CFLAGS: -I/usr/local/include
+#cgo linux freebsd pkg-config: sqlite3
+#cgo !linux,!freebsd LDFLAGS: -lsqlite3
 
 #include <sqlite3.h>
 #include <stdlib.h>


### PR DESCRIPTION
Recently I was playing with custom builds of libsqlite3 and neither
-lsqlite3 without other options find the library, not the compilation at
all works because libsqlite3 headers cannot be found.

There is established way to make this all working: by using pkg-config
builder can query it for a "package" cflags or libs e.g. this way:

	$ pkg-config --cflags sqlite3
	-I/home/kirr/local/sqlite/include

	$ pkg-config --libs sqlite3
	-L/home/kirr/local/sqlite/lib -lsqlite3

and use so-provided flags for the build.

And if the build is not custom pkg-config will just report cflags/libs
for a system package:

	$ pkg-config --cflags sqlite3

	$ pkg-config --libs sqlite3
	-lsqlite3

Since CGo provides support for pkg-config out of the box [1] we can use
it to get proper libsqlite3 CFLAGS/LDFLAGS.

I guess FreeBSD flags (added in e90ca0e4) becomes also not needed,
because by default pkg-config searches for package descriptions in
/usr/local/{lib,share}/pkgconfig too, but I'm not changing that since
Debian GNU/Linux is the only system I have at hand and can test.

[1] https://golang.org/cmd/cgo/#Shdr-Using_cgo_with_the_go_command