### PR TITLE
fixup! open: Fix error message

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -44,7 +44,7 @@ func (e OpenError) Error() string {
 	if file == "" {
 		file = "(temporary)"
 	}
-	s := fmt.Sprintf("%s: ", file)
+	s := fmt.Sprintf("%s: open: ", file)
 	codeErr := e.Code.Error()
 	if len(e.Msg) > 0 {
 		s += e.Msg


### PR DESCRIPTION
This commit fixes 0d47edb6. Recently I hit the following: I was trying
to open the database via

	sqlite3.Open(dburl, sqlite3.OpenNoMutex)

i.e. by passing flags, but erroneously no OpenReadWrite or something
similar, and got

	"testdata/1.sqlite: bad parameter or other API misuse"

as the error.

The message was confusing because there is no "open" action in it, so
add the action to OpenError and the mesage becomes:

	"testdata/1.sqlite: open: bad parameter or other API misuse"

See full discussion for structure of error messages here:

https://github.com/gwenn/gosqlite/pull/14