### PR TITLE
readme: Add link to another emerging sqlite library

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ SQLite logs (SQLITE_CONFIG_LOG) can be activated by:
 
 https://github.com/mattn/go-sqlite3 (Nov 11, 2011)  
 https://github.com/mxk/go-sqlite (Feb 12, 2013)  
+https://github.com/crawshaw/sqlite (Mar 28, 2018)
 
 ### Additions:
 


### PR DESCRIPTION
https://crawshaw.io/blog/go-and-sqlite describes the rationale, but it
overlaps with github.com/gwenn/gosqlite in many places.