### PR TITLE
Add EnableDefensive() function for database connections

### DIFF
--- a/config.go
+++ b/config.go
@@ -76,11 +76,15 @@ func EnableSharedCache(b bool) error {
 	return Errno(rv)
 }
 
+/* Database Connection Configuration Options
+//   https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
+ */
+
 // EnableFKey enables or disables the enforcement of foreign key constraints.
 // Calls sqlite3_db_config(db, SQLITE_DBCONFIG_ENABLE_FKEY, b).
 // Another way is PRAGMA foreign_keys = boolean;
 //
-// (See http://sqlite.org/c3ref/c_dbconfig_enable_fkey.html)
+// (See https://www.sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigenablefkey)
 func (c *Conn) EnableFKey(b bool) (bool, error) {
 	return c.queryOrSetEnableDbConfig(C.SQLITE_DBCONFIG_ENABLE_FKEY, btocint(b))
 }
@@ -89,7 +93,7 @@ func (c *Conn) EnableFKey(b bool) (bool, error) {
 // Calls sqlite3_db_config(db, SQLITE_DBCONFIG_ENABLE_FKEY, -1).
 // Another way is PRAGMA foreign_keys;
 //
-// (See http://sqlite.org/c3ref/c_dbconfig_enable_fkey.html)
+// (See https://www.sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigenablefkey)
 func (c *Conn) IsFKeyEnabled() (bool, error) {
 	return c.queryOrSetEnableDbConfig(C.SQLITE_DBCONFIG_ENABLE_FKEY, -1)
 }
@@ -97,7 +101,7 @@ func (c *Conn) IsFKeyEnabled() (bool, error) {
 // EnableTriggers enables or disables triggers.
 // Calls sqlite3_db_config(db, SQLITE_DBCONFIG_ENABLE_TRIGGER, b).
 //
-// (See http://sqlite.org/c3ref/c_dbconfig_enable_fkey.html)
+// (See https://www.sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigenabletrigger)
 func (c *Conn) EnableTriggers(b bool) (bool, error) {
 	return c.queryOrSetEnableDbConfig(C.SQLITE_DBCONFIG_ENABLE_TRIGGER, btocint(b))
 }
@@ -105,9 +109,17 @@ func (c *Conn) EnableTriggers(b bool) (bool, error) {
 // AreTriggersEnabled checks if triggers are enabled.
 // Calls sqlite3_db_config(db, SQLITE_DBCONFIG_ENABLE_TRIGGER, -1)
 //
-// (See http://sqlite.org/c3ref/c_dbconfig_enable_fkey.html)
+// (See https://www.sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigenabletrigger)
 func (c *Conn) AreTriggersEnabled() (bool, error) {
 	return c.queryOrSetEnableDbConfig(C.SQLITE_DBCONFIG_ENABLE_TRIGGER, -1)
+}
+
+// EnableDefensive enables defensive mode for the database connection.
+// Calls sqlite3_db_config(db, SQLITE_DBCONFIG_DEFENSIVE, 1).
+//
+// (See https://www.sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigdefensive)
+func (c *Conn) EnableDefensive() (bool, error) {
+	return c.queryOrSetEnableDbConfig(C.SQLITE_DBCONFIG_DEFENSIVE, 1)
 }
 
 func (c *Conn) queryOrSetEnableDbConfig(key, i C.int) (bool, error) {


### PR DESCRIPTION
Just adding this because I'm implementing the security practices in [Defense Against Dark Arts](https://www.sqlite.org/security.html) for the [DBHub.io](https://github.com/sqlitebrowser/dbhub.io) project.

The updated URLs for the database connection options are a bit strange, as they all refer to c_dbconfig_defensive.html.  That seems to be the most recent listing of the options, rather than the expected c_dbconfig.html.  No idea why. :shrug: 